### PR TITLE
Remove version from show-plugin btest

### DIFF
--- a/tests/Baseline/roca.show-plugin/output
+++ b/tests/Baseline/roca.show-plugin/output
@@ -1,4 +1,4 @@
-Johanna::ROCA - ROCA: Vulnerable RSA generation (CVE-2017-15361) key tester (dynamic, version 0.1)
+Johanna::ROCA - ROCA: Vulnerable RSA generation (CVE-2017-15361) key tester (dynamic, version)
     [Function] roca_vulnerable_mod
     [Function] roca_vulnerable_cert
 

--- a/tests/roca/show-plugin.bro
+++ b/tests/roca/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN Johanna::ROCA >output
+# @TEST-EXEC: bro -NN Johanna::ROCA |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.